### PR TITLE
Add required Predicates for FindCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,11 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.EmailMatchesPredicate;
+import seedu.address.model.person.GroupMatchesPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneMatchesPredicate;
+import seedu.address.model.tag.TagMatchesPredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -21,6 +25,10 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;
+    private EmailMatchesPredicate emailPredicate;
+    private GroupMatchesPredicate groupPredicate;
+    private PhoneMatchesPredicate phonePredicate;
+    private TagMatchesPredicate tagMatchesPredicate;
 
     public FindCommand(NameContainsKeywordsPredicate predicate) {
         this.predicate = predicate;

--- a/src/main/java/seedu/address/model/person/EmailMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailMatchesPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+public class EmailMatchesPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public EmailMatchesPredicate(String s) {
+        keyword = s;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EmailMatchesPredicate)) {
+            return false;
+        }
+
+        EmailMatchesPredicate e = (EmailMatchesPredicate) other;
+        return keyword.equals(e.keyword);
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/GroupMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/GroupMatchesPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+public class GroupMatchesPredicate implements Predicate<Person> {
+    private final String keyword;
+
+    public GroupMatchesPredicate(String s) {
+        keyword = s;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof GroupMatchesPredicate)) {
+            return false;
+        }
+
+        GroupMatchesPredicate e = (GroupMatchesPredicate) other;
+        return keyword.equals(e.keyword);
+    }
+}

--- a/src/main/java/seedu/address/model/person/PhoneMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneMatchesPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+public class PhoneMatchesPredicate implements Predicate<Person> {
+    private final String numToMatch;
+
+    public PhoneMatchesPredicate(String s) {
+        numToMatch = s;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof PhoneMatchesPredicate)) {
+            return false;
+        }
+
+        PhoneMatchesPredicate predicate = (PhoneMatchesPredicate) other;
+        return numToMatch.equals(predicate.numToMatch);
+    }
+}

--- a/src/main/java/seedu/address/model/tag/TagMatchesPredicate.java
+++ b/src/main/java/seedu/address/model/tag/TagMatchesPredicate.java
@@ -1,0 +1,11 @@
+package seedu.address.model.tag;
+
+import java.util.function.Predicate;
+
+public class TagMatchesPredicate implements Predicate<Tag> {
+
+    @Override
+    public boolean test(Tag tag) {
+        return false;
+    }
+}


### PR DESCRIPTION
FindCommand now requires up to 5 predicates
to be matched. Added the skeleton of these and
edit FindCommand to include these predicates

Let's add correct logic to the test function
of these skeletons.